### PR TITLE
reconfigured ESLint to ensure the max-len rule ignores long imports.

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -83,7 +83,7 @@ module.exports = {
       code: 80,
       tabWidth: 2,
       ignoreUrls: true,
-      ignorePattern: 'goog\.(module|require)',
+      ignorePattern: '^import\\s.+\\sfrom\\s.+;$',
     }],
     '@stylistic/key-spacing': 'error',
     '@stylistic/keyword-spacing': 'error',


### PR DESCRIPTION
Reconfigured ESLint to ensure the  `@stylistic/max-len` rule ignores **long imports**.